### PR TITLE
feat: Rename PostgreSQL schema drop command

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ services:
 
 Usage:
 ```bash
-php bin/console doctrine:schema:delete <schema_name>
+php bin/console doctrine:database:schema:drop <schema_name>
 ```
 
 **Security Note:** You can specify disallowed schema names to prevent accidental deletion of critical schemas like `public`.

--- a/src/Command/Doctrine/DoctrineSchemaDropCommand.php
+++ b/src/Command/Doctrine/DoctrineSchemaDropCommand.php
@@ -18,7 +18,7 @@ class DoctrineSchemaDropCommand extends AbstractDoctrineSchemaCommand
         Connection $connection,
         private readonly array $disallowedSchemaNames = [],
     ) {
-        parent::__construct('doctrine:schema:delete', $connection);
+        parent::__construct('doctrine:database:schema:drop', $connection);
     }
 
     protected function execute(


### PR DESCRIPTION
Rename `doctrine:schema:delete` command to avoid conflict with Symfony `doctrine:schema:drop` command alias (`d.s.d`)